### PR TITLE
Add `develop` to `contributing.md` guideline

### DIFF
--- a/help/contributing.md
+++ b/help/contributing.md
@@ -41,7 +41,7 @@ This is a high-level view of project contribution:
 2. Open the project using [IntelliJ IDEA](https://www.jetbrains.com/idea/)
 3. Make changes
 4. Add Tests if needed
-5. Open the Pull Request
+5. Open the Pull Request to branch `develop`
 
 {% hint style="info" %}
 See the [developer readme](https://github.com/LemonAppDev/konsist/blob/main/DeveloperReadme.md) containing more information about the project.


### PR DESCRIPTION
When I was going to create a branch into Konsist repository, I had to check in the previous (or current) PRs to which branch I should create a PR to. Maybe it's not necessary because it can be understood if you are coming from other Open Source cases but, it could be useful. Feel free to ignore and cancel this PR.

- Added the branch to the contribution guideline