### PR TITLE
Fix assert references, fix typo, add source set example

### DIFF
--- a/getting-started/getting-started/README.md
+++ b/getting-started/getting-started/README.md
@@ -163,7 +163,7 @@ class ControllerClassKonsistTest {
 }
 ```
 
-The above snippet presents a complete example of a test verifying that all classes annotated with `RestController` annotation reside in the `controler` package. Since scope is created from all project files this test will verify existing and new classes.
+The above snippet presents a complete example of a test verifying that all classes annotated with `RestController` annotation reside in the `controller` package. Since scope is created from all project files this test will verify existing and new classes.
 
 {% hint style="info" %}
 This test is written using [JUnit](https://junit.org/) testing framework that should also be added as a project dependency (see [starter projects](https://github.com/LemonAppDev/konsist/tree/main/samples/starter-projects)).

--- a/inspiration/snippets/android-snippets.md
+++ b/inspiration/snippets/android-snippets.md
@@ -15,7 +15,7 @@ fun `classes extending 'ViewModel' should have 'ViewModel' suffix`() {
         .scopeFromProject()
         .classes()
         .withParentOf(ViewModel::class)
-        .assertTrue { it.name.endsWith("ViewModel") }
+        .assert { it.name.endsWith("ViewModel") }
 }
 ```
 
@@ -29,7 +29,7 @@ fun `Every 'ViewModel' public property has 'Flow' type`() {
         .classes()
         .withParentOf(ViewModel::class)
         .properties()
-        .assertTrue {
+        .assert {
             it.hasPublicOrDefaultModifier && it.hasType { type -> type.name == "kotlinx.coroutines.flow.Flow" }
         }
 }
@@ -44,7 +44,7 @@ fun `'Repository' classes should reside in 'repository' package`() {
         .scopeFromProject()
         .classes()
         .withNameEndingWith("Repository")
-        .assertTrue { it.resideInPackage("..repository..") }
+        .assert { it.resideInPackage("..repository..") }
 }
 ```
 
@@ -56,7 +56,7 @@ fun `no class should use Android util logging`() {
     Konsist
         .scopeFromProject()
         .files
-        .assertFalse { it.hasImport { import -> import.name == "android.util.Log" } }
+        .assertNot { it.hasImport { import -> import.name == "android.util.Log" } }
 }
 ```
 

--- a/inspiration/snippets/architecture-snippets.md
+++ b/inspiration/snippets/architecture-snippets.md
@@ -31,7 +31,7 @@ fun `every file in module reside in module specific package`() {
     Konsist
         .scopeFromProject()
         .files
-        .assertTrue { it.packagee?.fullyQualifiedName?.startsWith(it.moduleName) }
+        .assert { it.packagee?.fullyQualifiedName?.startsWith(it.moduleName) }
 }
 ```
 
@@ -42,7 +42,7 @@ fun `every file in module reside in module specific package`() {
 fun `files reside in package that is derived from module name`() {
     Konsist.scopeFromProduction()
         .files
-        .assertTrue {
+        .assert {
             /*
             module -> package name:
             feature_meal_planner -> mealplanner

--- a/inspiration/snippets/clean-architecture-snippets.md
+++ b/inspiration/snippets/clean-architecture-snippets.md
@@ -30,7 +30,7 @@ fun `classes with 'UseCase' suffix should reside in 'domain' and 'usecase' packa
         .scopeFromProject()
         .classes()
         .withNameEndingWith("UseCase")
-        .assertTrue { it.resideInPackage("..domain..usecase..") }
+        .assert { it.resideInPackage("..domain..usecase..") }
 }
 ```
 
@@ -43,7 +43,7 @@ fun `classes with 'UseCase' suffix should have single 'public operator' method n
         .scopeFromProject()
         .classes()
         .withNameEndingWith("UseCase")
-        .assertTrue {
+        .assert {
             val hasSingleInvokeOperatorMethod = it.hasFunction { function ->
                 function.name == "invoke" && function.hasPublicOrDefaultModifier && function.hasOperatorModifier
             }
@@ -62,7 +62,7 @@ fun `interfaces with 'Repository' annotation should reside in 'data' package`() 
         .scopeFromProject()
         .interfaces()
         .withAnnotationOf(Repository::class)
-        .assertTrue { it.resideInPackage("..data..") }
+        .assert { it.resideInPackage("..data..") }
 }
 ```
 
@@ -75,7 +75,7 @@ fun `every UseCase class has test`() {
         .scopeFromProduction()
         .classes()
         .withParentNamed("UseCase")
-        .assertTrue { it.hasTestClass() }
+        .assert { it.hasTestClass() }
 }
 ```
 

--- a/inspiration/snippets/general-snippets.md
+++ b/inspiration/snippets/general-snippets.md
@@ -9,7 +9,7 @@ fun `files in 'ext' package must have name ending with 'Ext'`() {
         .scopeFromProject()
         .files
         .withPackage("..ext..")
-        .assertTrue { it.hasNameEndingWith("Ext") }
+        .assert { it.hasNameEndingWith("Ext") }
 }
 ```
 
@@ -21,7 +21,7 @@ fun `properties are declared before functions`() {
     Konsist
         .scopeFromProject()
         .classes()
-        .assertTrue {
+        .assert {
             val lastKoPropertyDeclarationIndex = it
                 .declarations(includeNested = false, includeLocal = false)
                 .indexOfLastInstance<KoPropertyDeclaration>()
@@ -49,7 +49,7 @@ fun `every constructor parameter has name derived from parameter type`() {
         .classes()
         .constructors
         .parameters
-        .assertTrue {
+        .assert {
             val nameTitleCase = it.name.replaceFirstChar { char -> char.titlecase(Locale.getDefault()) }
             nameTitleCase == it.type.sourceType
         }
@@ -65,7 +65,7 @@ fun `every class constructor has alphabetically ordered parameters`() {
         .scopeFromProject()
         .classes()
         .constructors
-        .assertTrue {
+        .assert {
             val names = it.parameters.map { parameter -> parameter.name }
             val sortedNames = names.sorted()
             names == sortedNames
@@ -81,7 +81,7 @@ fun `companion object is last declaration in the class`() {
     Konsist
         .scopeFromProject()
         .classes()
-        .assertTrue {
+        .assert {
             val companionObject = it.objects(includeNested = false).lastOrNull { obj ->
                 obj.hasModifier(KoModifier.COMPANION)
             }
@@ -105,7 +105,7 @@ fun `every value class has parameter named 'value'`() {
         .classes()
         .withValueModifier()
         .primaryConstructors
-        .assertTrue { it.hasParameterWithName("value") }
+        .assert { it.hasParameterWithName("value") }
 }
 ```
 
@@ -117,7 +117,7 @@ fun `no empty files allowed`() {
     Konsist
         .scopeFromProject()
         .files
-        .assertFalse { it.text.isEmpty() }
+        .assertNot { it.text.isEmpty() }
 }
 ```
 
@@ -130,7 +130,7 @@ fun `no field should have 'm' prefix`() {
         .scopeFromProject()
         .classes()
         .properties()
-        .assertFalse {
+        .assertNot {
             val secondCharacterIsUppercase = it.name.getOrNull(1)?.isUpperCase() ?: false
             it.name.startsWith('m') && secondCharacterIsUppercase
         }
@@ -146,7 +146,7 @@ fun `no class should use field injection`() {
         .scopeFromProject()
         .classes()
         .properties()
-        .assertFalse { it.hasAnnotationOf<Inject>() }
+        .assertNot { it.hasAnnotationOf<Inject>() }
 }
 ```
 
@@ -158,7 +158,7 @@ fun `no class should use Java util logging`() {
     Konsist
         .scopeFromProject()
         .files
-        .assertFalse { it.hasImport { import -> import.name == "java.util.logging.." } }
+        .assertNot { it.hasImport { import -> import.name == "java.util.logging.." } }
 }
 ```
 
@@ -170,7 +170,7 @@ fun `package name must match file path`() {
     Konsist
         .scopeFromProject()
         .packages
-        .assertTrue { it.hasMatchingPath }
+        .assert { it.hasMatchingPath }
 }
 ```
 
@@ -182,7 +182,7 @@ fun `no wildcard imports allowed`() {
     Konsist
         .scopeFromProject()
         .imports
-        .assertFalse { it.isWildcard }
+        .assertNot { it.isWildcard }
 }
 ```
 
@@ -194,7 +194,19 @@ fun `forbid the usage of 'forbiddenString' in file`() {
     Konsist
         .scopeFromProject()
         .files
-        .assertFalse { it.text.contains("forbiddenString") }
+        .assertNot { it.text.contains("forbiddenString") }
 }
 ```
 
+## 14. All files with JUnit @Test annotations end with the name "Tests"
+
+```kotlin
+@Test
+fun `all files with tests in them should end with 'Tests'`() {
+Konsist
+    .scopeFromSourceSet("test") // Only look within test files
+    .files
+    .filter { it.functions().any { fn -> fn.hasAnnotationOf(Test::class) } } // All files with a @Test function
+    .assert { it.hasNameEndingWith("Tests") }
+}
+```

--- a/inspiration/snippets/kotest-snippets.md
+++ b/inspiration/snippets/kotest-snippets.md
@@ -9,7 +9,7 @@ class UseCaseTest : FreeSpec({
             .scopeFromProject()
             .classes()
             .withNameEndingWith("UseCase")
-            .assertTrue { it.hasTestClass() }
+            .assert { it.hasTestClass() }
     }
 })
 ```
@@ -24,10 +24,10 @@ class UseCaseTests : FreeSpec({
         .withNameEndingWith("UseCase")
         .forEach { useCase ->
             "${useCase.name} should have test" {
-                useCase.assertTrue { it.hasTestClass() }
+                useCase.assert { it.hasTestClass() }
             }
             "${useCase.name} should reside in ..domain..usecase.. package" {
-                useCase.assertTrue { it.resideInPackage("..domain..usecase..") }
+                useCase.assert { it.resideInPackage("..domain..usecase..") }
             }
             "${useCase.name} should ..." {
                 // another Konsist assert

--- a/inspiration/snippets/kotlin-serialization-snippets.md
+++ b/inspiration/snippets/kotlin-serialization-snippets.md
@@ -13,7 +13,7 @@ fun `classes annotated with 'Serializable' have all properties annotated with 'S
         .classes()
         .withAnnotationOf(Serializable::class)
         .properties()
-        .assertTrue {
+        .assert {
             it.hasAnnotationOf(SerialName::class)
         }
 }
@@ -29,7 +29,7 @@ fun `enum classes annotated with 'Serializable' have all enum constants annotate
         .withEnumModifier()
         .withAnnotationOf(Serializable::class)
         .enumConstants
-        .assertTrue { it.hasAnnotationOf(SerialName::class) }
+        .assert { it.hasAnnotationOf(SerialName::class) }
 }
 ```
 

--- a/inspiration/snippets/library-snippets.md
+++ b/inspiration/snippets/library-snippets.md
@@ -8,7 +8,7 @@ fun `every api declaration has KDoc`() {
     Konsist
         .scopeFromPackage("..api..")
         .declarationsOf<KoKDocProvider>()
-        .assertTrue { it.hasKDoc }
+        .assert { it.hasKDoc }
 }
 ```
 
@@ -19,7 +19,7 @@ fun `every api declaration has KDoc`() {
 fun `every function with parameters has a param tags`() {
     Konsist.scopeFromPackage("..api..")
         .functions()
-        .assertTrue { it.hasValidKDocParamTags() }
+        .assert { it.hasValidKDocParamTags() }
 }
 ```
 
@@ -30,7 +30,7 @@ fun `every function with parameters has a param tags`() {
 fun `every function with return value has a return tag`() {
     Konsist.scopeFromPackage("..api..")
         .functions()
-        .assertTrue { it.hasValidKDocReturnTag() }
+        .assert { it.hasValidKDocReturnTag() }
 }
 ```
 
@@ -41,7 +41,7 @@ fun `every function with return value has a return tag`() {
 fun `every extension has a receiver tag`() {
     Konsist.scopeFromPackage("..api..")
         .declarationsOf<KoReceiverTypeProvider>()
-        .assertTrue { it.hasValidKDocReceiverTag() }
+        .assert { it.hasValidKDocReceiverTag() }
 }
 ```
 
@@ -53,7 +53,7 @@ fun `every public function in api package must have explicit return type`() {
     Konsist
         .scopeFromPackage("..api..")
         .functions()
-        .assertTrue { it.hasReturnType() }
+        .assert { it.hasReturnType() }
 }
 ```
 
@@ -65,7 +65,7 @@ fun `every public property in api package must have specify type explicitly`() {
     Konsist
         .scopeFromPackage("..api..")
         .properties()
-        .assertTrue { it.hasType() }
+        .assert { it.hasType() }
 }
 ```
 

--- a/inspiration/snippets/sample/sample-snippets.md
+++ b/inspiration/snippets/sample/sample-snippets.md
@@ -12,7 +12,7 @@ fun `classes extending 'ViewModel' should have 'ViewModel' suffix`() {
         .scopeFromProject()
         .classes()
         .withParentOf(ViewModel::class)
-        .assertTrue { it.name.endsWith("ViewModel") }
+        .assert { it.name.endsWith("ViewModel") }
 }
 ```
 
@@ -26,7 +26,7 @@ fun `Every 'ViewModel' public property has 'Flow' type`() {
         .classes()
         .withParentOf(ViewModel::class)
         .properties()
-        .assertTrue {
+        .assert {
             it.hasPublicOrDefaultModifier && it.hasType { type -> type.name == "kotlinx.coroutines.flow.Flow" }
         }
 }
@@ -41,7 +41,7 @@ fun `'Repository' classes should reside in 'repository' package`() {
         .scopeFromProject()
         .classes()
         .withNameEndingWith("Repository")
-        .assertTrue { it.resideInPackage("..repository..") }
+        .assert { it.resideInPackage("..repository..") }
 }
 ```
 
@@ -53,7 +53,7 @@ fun `no class should use Android util logging`() {
     Konsist
         .scopeFromProject()
         .files
-        .assertFalse { it.hasImport { import -> import.name == "android.util.Log" } }
+        .assertNot { it.hasImport { import -> import.name == "android.util.Log" } }
 }
 ```
 

--- a/inspiration/snippets/spring-snippets.md
+++ b/inspiration/snippets/spring-snippets.md
@@ -11,7 +11,7 @@ fun `interfaces with 'Repository' annotation should have 'Repository' suffix`() 
         .scopeFromProject()
         .interfaces()
         .withAnnotationOf(Repository::class)
-        .assertTrue { it.hasNameEndingWith("Repository") }
+        .assert { it.hasNameEndingWith("Repository") }
 }
 ```
 
@@ -24,7 +24,7 @@ fun `classes with 'RestController' annotation should have 'Controller' suffix`()
         .scopeFromProject()
         .classes()
         .withAnnotationOf(RestController::class)
-        .assertTrue { it.hasNameEndingWith("Controller") }
+        .assert { it.hasNameEndingWith("Controller") }
 }
 ```
 
@@ -37,7 +37,7 @@ fun `classes with 'RestController' annotation should reside in 'controller' pack
         .scopeFromProject()
         .classes()
         .withAnnotationOf(RestController::class)
-        .assertTrue { it.resideInPackage("..controller..") }
+        .assert { it.resideInPackage("..controller..") }
 }
 ```
 

--- a/inspiration/snippets/test-snippets.md
+++ b/inspiration/snippets/test-snippets.md
@@ -8,7 +8,7 @@ fun `every class has test`() {
     Konsist
         .scopeFromProduction()
         .classes()
-        .assertTrue { it.hasTestClass() }
+        .assert { it.hasTestClass() }
 }
 ```
 
@@ -21,7 +21,7 @@ fun `every class - except data and value class - has test`() {
         .scopeFromProduction()
         .classes()
         .withoutModifier(KoModifier.DATA, KoModifier.VALUE)
-        .assertTrue { it.hasTestClass() }
+        .assert { it.hasTestClass() }
 }
 ```
 
@@ -33,7 +33,7 @@ fun `test classes should have test subject named sut`() {
     Konsist
         .scopeFromTest()
         .classes()
-        .assertTrue {
+        .assert {
             val type = it.name.removeSuffix("Test")
             val sut = it
                 .properties()
@@ -56,7 +56,7 @@ fun `test classes should have all members private besides tests`() {
         .filterIsInstance<KoAnnotationProvider>()
         .withoutAnnotationOf(Test::class, ParameterizedTest::class, RepeatedTest::class)
         .filterIsInstance<KoVisibilityModifierProvider>()
-        .assertTrue { it.hasPrivateModifier }
+        .assert { it.hasPrivateModifier }
 }
 ```
 
@@ -69,7 +69,7 @@ fun `don't use JUnit4 Test annotation`() {
         .scopeFromProject()
         .classes()
         .functions()
-        .assertFalse { it.hasAnnotationWithName("org.junit.Test") } // should be only org.junit.jupiter.api.Test
+        .assertNot { it.hasAnnotationWithName("org.junit.Test") } // should be only org.junit.jupiter.api.Test
 }
 ```
 


### PR DESCRIPTION
Great framework! I spent my day playing with it, and I found a few issues and wanted to contribute. This PR:

1. Fixes incorrect `assert` usage within snippets - seems like `assertTrue` and `assertFalse` were recently changed, so I updated these snippets
2. Fixed a typo ("controler") that I saw in one of the instructions
3. Added an example to the general snippets - I found this to be a useful test, and it also provides an example of the usage for `scopeFromSourceSet` and a more complicated filter operation that involves filtering on sub-declarations.

Happy to change anything here. Thanks!