### PR TITLE
Fix "Starter Projects" links for Spring Boot

### DIFF
--- a/inspiration/starter-projects.md
+++ b/inspiration/starter-projects.md
@@ -11,7 +11,7 @@ Konsist provides preconfigured sample projects. Each project contains a complete
   * [android-gradle-kotlin-junit-5](https://github.com/LemonAppDev/konsist/tree/main/samples/starter-projects/konsist-starter-android-gradle-kotlin-junit-5)
 * Spring
   * [spring-gradle-groovy-junit-5](https://github.com/LemonAppDev/konsist/tree/main/samples/starter-projects/konsist-starter-spring-gradle-groovy-junit-5)
-  * [spring-gradle-kotlin-junit-5](https://github.com/LemonAppDev/konsist/tree/main/samples/starter-projects/konsist-starter-android-gradle-kotlin-junit-5)
-  * [spring-maven-junit5](https://github.com/LemonAppDev/konsist/tree/main/samples/starter-projects/konsist-starter-spring-gradle-kotlin-junit-5)
+  * [spring-gradle-kotlin-junit-5](https://github.com/LemonAppDev/konsist/tree/main/samples/starter-projects/konsist-starter-spring-gradle-kotlin-junit-5)
+  * [spring-maven-junit5](https://github.com/LemonAppDev/konsist/tree/main/samples/starter-projects/konsist-starter-spring-maven-junit5)
 * Kotlin Multiplatform
   * kotlin-multiplatform-gradle-kotlin-junit5


### PR DESCRIPTION
This commit fixes the links for the following projects:

- `spring-gradle-kotlin-junit-5` (Previously pointed to Android project)
- `spring-maven-junit5` (Previously pointed to the project above)